### PR TITLE
No longer using root user in python base container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ install:
   - docker-compose -f docker-compose.yml up -d --build
 
 script:
-  - docker ps -a | grep -q "${DOCKER_IMAGE}"
+  # Not yet
+  # - docker ps -a | grep -q "${DOCKER_IMAGE}"
   - cd docker-bench-security
   - sudo sh docker-bench-security.sh -c container_images
   - docker run -d --name db arminc/clair-db

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 
 script:
   # Not yet
-  - curl -s "http://$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'):8000/"" -I | head -n 1 | cut -d$' ' -f2 | grep -q 200
+  - sleep 5 && curl -s "http://$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'):8000/" -I | head -n 1 | cut -d$' ' -f2 | grep -q 200
   - cd docker-bench-security
   - sudo sh docker-bench-security.sh -c container_images
   - docker run -d --name db arminc/clair-db

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 
 script:
   # Not yet
-  # - docker ps -a | grep -q "${DOCKER_IMAGE}"
+  - curl -s "http://$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'):8000/"" -I | head -n 1 | cut -d$' ' -f2 | grep -q 200
   - cd docker-bench-security
   - sudo sh docker-bench-security.sh -c container_images
   - docker run -d --name db arminc/clair-db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Dockerfile
-- docker-compose.env
-- docker-compose.yml
-- .travis.yml
- 
+- kmschoep@usgs.gov - Dockerfile
+- kmschoep@usgs.gov - docker-compose.env
+- kmschoep@usgs.gov - docker-compose.yml
+- kmschoep@usgs.gov - .travis.yml
+- isuftin@usgs.gov - python user
+
+### Changed
+ - isuftin@usgs.gov - Moved lines around in Dockerfile
+ - isuftin@usgs.gov - Dockerfile now uses python user instead of root
+ - isuftin@usgs.gov - Removed check in travis for a running container
+ - isuftin@usgs.gov - Split out config to config.env and secrets.yml
+ - isuftin@usgs.gov - docker-compose now mounts certificates into python home dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - kmschoep@usgs.gov - docker-compose.yml
 - kmschoep@usgs.gov - .travis.yml
 - isuftin@usgs.gov - python user
+- isuftin@usgs.gov - Added curl check in travis to verify http server is running
 
 ### Changed
  - isuftin@usgs.gov - Moved lines around in Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
 FROM alpine:3.8
 
-RUN apk update && apk upgrade && mkdir /local
-RUN apk add --update --no-cache \
+LABEL maintaner="gs-w_eto@usgs.gov"
+
+ENV USER=python
+ENV HOME=/home/$USER
+ENV bind_ip 0.0.0.0
+ENV requireSsl=true
+ENV serverPort=443
+ENV serverContextPath=/
+ENV oauthResourceTokenKeyUri=https://example.gov/oauth/token_key
+ENV jwt_algorithm=HS256
+ENV jwt_decode_audience=default
+ENV ssl_cert_path=$HOME/wildcard-ssl.crt
+ENV ssl_key_path=$HOME/wildcard-ssl.key
+
+RUN apk update && apk upgrade && apk add --update --no-cache \
   python3 \
   python3-dev \
   build-base \
@@ -10,16 +23,15 @@ RUN apk add --update --no-cache \
   openssl-dev \
   openssl \
   curl && \
-  rm -rf /var/cache/apk/* && \
-  export PIP_CERT="/etc/ssl/certs/ca-certificates.crt" && \
-  pip3 install --upgrade pip
-ENV bind_ip 0.0.0.0
-ENV requireSsl=true
-ENV serverPort=443
-ENV serverContextPath=/
+  rm -rf /var/cache/apk/*
 
-ENV oauthResourceTokenKeyUri=https://example.gov/oauth/token_key
-ENV jwt_algorithm=HS256
-ENV jwt_decode_audience=default
-ENV ssl_cert_path=/wildcard-ssl.crt
-ENV ssl_key_path=/wildcard-ssl.key
+RUN export PIP_CERT="/etc/ssl/certs/ca-certificates.crt" && \
+  python3 -m ensurepip && \
+  rm -r /usr/lib/python*/ensurepip && \
+  pip3 install --upgrade pip && \
+  if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi
+
+RUN adduser -D -u 1000 $USER
+WORKDIR $HOME
+USER $USER
+RUN mkdir $HOME/local

--- a/config.env
+++ b/config.env
@@ -1,10 +1,9 @@
 requireSsl=true
 serverPort=443
 serverContextPath=/
-
 oauthResourceTokenKeyUri=https://example.gov/oauth/token_key
 jwt_algorithm=HS256
 jwt_decode_audience=default
-
-ssl_cert_path=/wildcard-ssl.crt
-ssl_key_path=/wildcard-ssl.key
+ssl_cert_path=/home/python/wildcard-ssl.crt
+ssl_key_path=/home/python/wildcard-ssl.key
+bind_ip=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,6 @@
       env_file:
         - config.env
         - secrets.env
+      ports:
+        - "8000:8000"
+      command: python -m http.server 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,16 @@
       file: ./config/certificates/wildcard-dev.crt
     ssl_key:
       file: ./config/certificates/wildcard-dev.key
-      
+
   services:
     mlr-python-base:
       build: .
       image: mlr-python-base
       secrets:
         - source: ssl_crt
-          target: /wildcard-ssl.crt
+          target: /home/python/wildcard-ssl.crt
         - source: ssl_key
-          target: /wildcard-ssl.key
+          target: /home/python/wildcard-ssl.key
       env_file:
-        - docker-compose.env
+        - config.env
+        - secrets.env


### PR DESCRIPTION
 - isuftin@usgs.gov - python user
- isuftin@usgs.gov - Moved lines around in Dockerfile
 - isuftin@usgs.gov - Dockerfile now uses python user instead of root
 - isuftin@usgs.gov - Removed check in travis for a running container
 - isuftin@usgs.gov - Split out config to config.env and secrets.yml
 - isuftin@usgs.gov - docker-compose now mounts certificates into python home dir